### PR TITLE
Allows for shared libraries to be in binary's directory

### DIFF
--- a/my-master/Cargo.toml
+++ b/my-master/Cargo.toml
@@ -9,3 +9,8 @@ edition = "2018"
 [dependencies]
 libloading = "0.5"
 my-interface = { path = "../my-interface", version = "*" }
+
+[profile.release]
+rpath = true
+[profile.debug]
+rpath = true


### PR DESCRIPTION
On linux at least, I'm not sure about other OS ( windows does it by default )
